### PR TITLE
log 関数の挙動

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -1,0 +1,2 @@
+require 'dydx'
+include Dydx

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,6 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in dydx.gemspec
 gem 'pry'
+gem 'pry-coolline'
+# gem 'pry-debugger'
 gemspec

--- a/lib/dydx/algebra.rb
+++ b/lib/dydx/algebra.rb
@@ -73,6 +73,7 @@ module Dydx
       class Pi;     include Operator::General; end
       class Log;    include Operator::General; end
       class Log2;   include Operator::General; end
+      class Log10;  include Operator::General; end
       class Sin;    include Operator::General; end
       class Cos;    include Operator::General; end
       class Tan;    include Operator::General; end

--- a/lib/dydx/algebra.rb
+++ b/lib/dydx/algebra.rb
@@ -72,6 +72,7 @@ module Dydx
       class E;      include Operator::General; end
       class Pi;     include Operator::General; end
       class Log;    include Operator::General; end
+      class Log2;   include Operator::General; end
       class Sin;    include Operator::General; end
       class Cos;    include Operator::General; end
       class Tan;    include Operator::General; end

--- a/lib/dydx/algebra/set.rb
+++ b/lib/dydx/algebra/set.rb
@@ -7,6 +7,7 @@ require 'dydx/algebra/set/e'
 require 'dydx/algebra/set/pi'
 require 'dydx/algebra/set/log'
 require 'dydx/algebra/set/log2'
+require 'dydx/algebra/set/log10'
 require 'dydx/algebra/set/sin'
 require 'dydx/algebra/set/cos'
 require 'dydx/algebra/set/tan'
@@ -73,6 +74,25 @@ module Dydx
           e1
         else
           Log2.new(formula)
+        end
+      end
+
+      def log10(formula)
+        # TODO: refactor with log function.
+        if formula.multiplication?
+          f, g = formula.f, formula.g
+          log10(f) + log10(g)
+        elsif formula.exponentiation?
+          f, g = formula.f, formula.g
+          g * log10(f)
+        elsif formula.is_1?
+          e0
+        elsif formula.is_a?(Num)
+          (formula.n == 10) ? e1 : log10(formula.n)
+        elsif formula == 10
+          e1
+        else
+          Log10.new(formula)
         end
       end
 

--- a/lib/dydx/algebra/set.rb
+++ b/lib/dydx/algebra/set.rb
@@ -6,6 +6,7 @@ require 'dydx/algebra/set/symbol'
 require 'dydx/algebra/set/e'
 require 'dydx/algebra/set/pi'
 require 'dydx/algebra/set/log'
+require 'dydx/algebra/set/log2'
 require 'dydx/algebra/set/sin'
 require 'dydx/algebra/set/cos'
 require 'dydx/algebra/set/tan'
@@ -53,6 +54,25 @@ module Dydx
           e1
         else
           Log.new(formula)
+        end
+      end
+
+      def log2(formula)
+        # TODO: refactor with log function.
+        if formula.multiplication?
+          f, g = formula.f, formula.g
+          log2(f) + log2(g)
+        elsif formula.exponentiation?
+          f, g = formula.f, formula.g
+          g * log2(f)
+        elsif formula.is_1?
+          e0
+        elsif formula.is_a?(Num)
+          (formula.n == 2) ? e1 : log2(formula.n)
+        elsif formula == 2
+          e1
+        else
+          Log2.new(formula)
         end
       end
 

--- a/lib/dydx/algebra/set/log10.rb
+++ b/lib/dydx/algebra/set/log10.rb
@@ -1,0 +1,22 @@
+module Dydx
+  module Algebra
+    module Set
+      class Log10 < Base
+        attr_accessor :f
+
+        def initialize(f)
+          @f = f
+        end
+
+        def to_s
+          "log10( #{f.to_s} )"
+        end
+
+        def differentiate(sym=:x)
+          f.d(sym) / (f * log(10))
+        end
+        alias_method :d, :differentiate
+      end
+    end
+  end
+end

--- a/lib/dydx/algebra/set/log2.rb
+++ b/lib/dydx/algebra/set/log2.rb
@@ -1,0 +1,22 @@
+module Dydx
+  module Algebra
+    module Set
+      class Log2 < Base
+        attr_accessor :f
+
+        def initialize(f)
+          @f = f
+        end
+
+        def to_s
+          "log2( #{f.to_s} )"
+        end
+
+        def differentiate(sym=:x)
+          f.d(sym) / (f * log(2))
+        end
+        alias_method :d, :differentiate
+      end
+    end
+  end
+end

--- a/spec/lib/algebra/set/log10_spec.rb
+++ b/spec/lib/algebra/set/log10_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Dydx::Algebra::Set::Log10 do
+  it { expect(log10(1)).to eq(_(0)) }
+  it { expect(log10(10)).to eq(_(1)) }
+  it { expect(log10(10 ^ :n)).to eq(:n) }
+  it { expect(log10(3 ^ :n).to_s).to eq('( n * log10( 3 ) )') }
+
+  describe '#to_s' do
+  end
+  describe '#differentiate' do
+    it { expect(log10(:x).d(:x).to_s).to eq('( 1 / ( x * log( 10 ) ) )') }
+  end
+  describe 'Calculate' do
+  end
+end

--- a/spec/lib/algebra/set/log2_spec.rb
+++ b/spec/lib/algebra/set/log2_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Dydx::Algebra::Set::Log2 do
+  it { expect(log2(1)).to eq(_(0)) }
+  it { expect(log2(2)).to eq(_(1)) }
+  it { expect(log2(2 ^ :n)).to eq(:n) }
+  it { expect(log2(3 ^ :n).to_s).to eq('( n * log2( 3 ) )') }
+
+  describe '#to_s' do
+  end
+  describe '#differentiate' do
+    it { expect(log2(:x).d(:x).to_s).to eq('( 1 / ( x * log( 2 ) ) )') }
+  end
+  describe 'Calculate' do
+  end
+end


### PR DESCRIPTION
It's niceeeeeeeeee gem!!

``` ruby
require 'dydx'
include Dydx

cos(x)
# => #<Dydx::Algebra::Set::Cos:0xba6f99b4 @x=:x>
cos(x).to_x
# => "cos( x )"

log(x)
# => ArgumentError: wrong number of arguments (1 for 0)
log = Dydx::Algebra::Set::Log.new(x)
# => #<Dydx::Algebra::Set::Log:0xba992c34 @f=:x>
log.to_s
# => "log( x )"
```

現状， log 関数はこのようにしか扱えないようですが，これは仕様なのでしょうか？
