### PR TITLE
Improve integral calc

### DIFF
--- a/lib/dydx/integrand.rb
+++ b/lib/dydx/integrand.rb
@@ -6,21 +6,27 @@ module Dydx
       @var = var
     end
 
-    def [](a, b, n = 100)
-      f = function
-      a, b = [a, b].map(&:to_f)
+    def [](a, b, n = 1000)
       raise ArgumentError, 'b should be greater than a' if a > b
+      f = function
       # HOT FIX: should implement Infinity class
       a = - 1000 if a == - Float::INFINITY
       b = 1000 if b == Float::INFINITY
 
+      a, b = [a, b].map(&:to_f)
+      n = [n, (b - a) * 2].max
+      n += 1 if n.to_i.odd?
       h = (b - a) / n
-      sum = 0.0
-      xi = ->(i){ a + h * i }
-      n.to_i.times do |i|
-        sum += ( f(xi.(i)) + 4.0 * f(xi.(i) + h / 2.0 ) + f(xi.(i) + h) )
-      end
-      ( h * sum ) / 6.0
+      x = ->(i){ a + h * i }
+
+      odd_sum = (1..n - 1).to_a.select(&:odd?).inject(0) { |sum, i| sum += f(x.(i))}
+      even_sum = (1..n - 1).to_a.select(&:even?).inject(0) { |sum, i| sum += f(x.(i))}
+      round_8( (h / 3) * (f(a) + f(b) + 2 * even_sum + 4 * odd_sum) )
+    end
+
+    def round_8(num)
+      return num if num.abs == Float::INFINITY
+      (num * 10 ** 8).round * 10.0 ** (-8)
     end
   end
 end

--- a/spec/lib/integrand_spec.rb
+++ b/spec/lib/integrand_spec.rb
@@ -15,17 +15,17 @@ describe Dydx:Integrand do
 
   it 'ex2' do
     f(x) <= x * x
-    expect(S(f(x), dx)[0, 1]).to eq(0.3333333333333334)
+    expect(S(f(x), dx)[0, 1]).to eq(0.33333333)
   end
 
   it 'ex3' do
     f(x) <= sin(x)
-    expect(S(f(x), dx)[0, Math::PI/2]).to eq(1.000000000021139)
+    expect(S(f(x), dx)[0, Math::PI/2]).to eq(1.0)
   end
 
   it 'ex4' do
     f(x) <= cos(x)
-    expect(S(f(x), dx)[0, Math::PI]).to eq(7.440786129085082e-17)
+    expect(S(f(x), dx)[0, Math::PI]).to eq(0.0)
   end
 
   it 'ex5' do
@@ -38,16 +38,16 @@ describe Dydx:Integrand do
     expect(f(0)).to eq(1)
     expect(f(1)).to eq(1.0/Math::E)
     expect(f(1000)).to eq(0)
-    expect(S(f(x), dx)[-1000, 1000, 3000]).to eq(1.7724538506374117)
+    expect(S(f(x), dx)[-1000, 1000, 3000]).to eq(1.77239273)
   end
 
   it 'ex7' do
     f(x) <= (1.0 / ( ( 2.0 * Math::PI ) ^ 0.5 ) ) * ( e ^ (- (x ^ 2) / 2) )
-    expect(S(f(x), dx)[-1000, 1000, 1000]).to eq(0.9952054164466917)
+    expect(S(f(x), dx)[-1000, 1000]).to eq(1.0)
   end
 
   it 'ex8' do
-    f(x) <= (1.0 / ( ( 2.0 * pi ) ^ 0.5 ) ) * ( e ^ (- (x ^ 2) / 2) )
-    expect(S(f(x), dx)[-oo, oo, 1000]).to eq(0.9952054164466917)
+    f(x) <= (1.0 / ( ( 2.0 * Math::PI ) ^ 0.5 ) ) * ( e ^ (- (x ^ 2) / 2) )
+    expect(S(f(x), dx)[-oo, oo]).to eq(1.0)
   end
 end


### PR DESCRIPTION
積分計算をより早く、より正確にしました.

出力結果を有効少数8桁とする事にしました.
(sinや正規分布の積分が綺麗になってうれしい）

Improve integral calculation more quickly, more accurately.

I define result  as the 8-digit effective minority 
(sin's calc come to look better)
