### PR TITLE
Change method names occurring rubocop CAUTION.

### DIFF
--- a/lib/dydx/algebra.rb
+++ b/lib/dydx/algebra.rb
@@ -9,7 +9,7 @@ module Dydx
 
     # TODO: Cyclomatic complexity for inverse is too high. [7/6]
     def inverse(x, operator)
-      if operator == :+ && x.is_0?
+      if operator == :+ && x.zero?
         e0
       elsif operator == :* && x.is_1?
         e1

--- a/lib/dydx/algebra.rb
+++ b/lib/dydx/algebra.rb
@@ -11,7 +11,7 @@ module Dydx
     def inverse(x, operator)
       if operator == :+ && x.zero?
         e0
-      elsif operator == :* && x.is_1?
+      elsif operator == :* && x.one?
         e1
       elsif x.is_a?(Inverse) && x.operator == operator
         x.x

--- a/lib/dydx/algebra/formula.rb
+++ b/lib/dydx/algebra/formula.rb
@@ -5,7 +5,7 @@ module Dydx
       attr_accessor :f, :operator, :g
 
       def initialize(f, g, operator)
-        g, f = f, g if g.is_num? && operator.commutative?
+        g, f = f, g if g.num? && operator.commutative?
         @f, @g, @operator = f, g, operator
       end
 
@@ -16,7 +16,7 @@ module Dydx
         when :* then (f.d(sym) * g) + (f * g.d(sym))
         when :^
           # TODO:
-          if g.is_num?
+          if g.num?
             f.d(sym) * g * (f ^ (g - 1))
           elsif f == sym
             g * (f ^ (g - 1))

--- a/lib/dydx/algebra/formula.rb
+++ b/lib/dydx/algebra/formula.rb
@@ -30,7 +30,7 @@ module Dydx
       alias_method :d, :differentiate
 
       def to_s
-        if formula?(:*) && (f.is_minus1? || g.is_minus1?)
+        if formula?(:*) && (f.minus1? || g.minus1?)
           "( - #{g} )"
         elsif g.inverse?(operator)
           "( #{f} #{inverse_ope(operator)} #{g.x} )"

--- a/lib/dydx/algebra/operator/parts/general.rb
+++ b/lib/dydx/algebra/operator/parts/general.rb
@@ -5,7 +5,7 @@ module Dydx
         module General
           %w(+ * ^).map(&:to_sym).each do |operator|
             define_method(operator) do |x|
-              if x.is_0?
+              if x.zero?
                 case operator
                 when :+ then self
                 when :* then x

--- a/lib/dydx/algebra/operator/parts/general.rb
+++ b/lib/dydx/algebra/operator/parts/general.rb
@@ -11,7 +11,7 @@ module Dydx
                 when :* then x
                 when :^ then e1
                 end
-              elsif x.is_1?
+              elsif x.one?
                 case operator
                 when :+ then super(x)
                 when :* then self

--- a/lib/dydx/algebra/operator/parts/interface.rb
+++ b/lib/dydx/algebra/operator/parts/interface.rb
@@ -6,7 +6,7 @@ module Dydx
           %w(+ - * / ^).map(&:to_sym).each do |operator|
             define_method(operator) do |x|
               x = ::Set::Num.new(x) if x.is_a?(Fixnum)
-              if operator == :/ && x.is_0?
+              if operator == :/ && x.zero?
                 fail ZeroDivisionError
               elsif [:-, :/].include?(operator)
                 send(inverse_ope(operator), inverse(x, inverse_ope(operator)))

--- a/lib/dydx/algebra/operator/parts/num.rb
+++ b/lib/dydx/algebra/operator/parts/num.rb
@@ -5,7 +5,7 @@ module Dydx
         module Num
           %w(+ * ^).map(&:to_sym).each do |operator|
             define_method(operator) do |x|
-              if is_0?
+              if zero?
                 case operator
                 when :+ then x
                 when :* then e0

--- a/lib/dydx/algebra/operator/parts/num.rb
+++ b/lib/dydx/algebra/operator/parts/num.rb
@@ -11,7 +11,7 @@ module Dydx
                 when :* then e0
                 when :^ then e0
                 end
-              elsif is_1?
+              elsif one?
                 case operator
                 when :+ then super(x)
                 when :* then x

--- a/lib/dydx/algebra/set.rb
+++ b/lib/dydx/algebra/set.rb
@@ -283,7 +283,7 @@ module Dydx
         elsif formula.exponentiation?
           f, g = formula.f, formula.g
           g * log(f)
-        elsif formula.is_1?
+        elsif formula.one?
           e0
         elsif formula.is_a?(E)
           e1
@@ -300,7 +300,7 @@ module Dydx
         elsif formula.exponentiation?
           f, g = formula.f, formula.g
           g * log2(f)
-        elsif formula.is_1?
+        elsif formula.one?
           e0
         elsif formula.is_a?(Num)
           (formula.n == 2) ? e1 : log2(formula.n)
@@ -319,7 +319,7 @@ module Dydx
         elsif formula.exponentiation?
           f, g = formula.f, formula.g
           g * log10(f)
-        elsif formula.is_1?
+        elsif formula.one?
           e0
         elsif formula.is_a?(Num)
           (formula.n == 10) ? e1 : log10(formula.n)

--- a/lib/dydx/helper.rb
+++ b/lib/dydx/helper.rb
@@ -42,8 +42,8 @@ module Dydx
       [1, 1.0].include?(self) || (is_a?(Num) && n.one?)
     end
 
-    def is_minus1?
-      [1, -1.0].include?(self) || (is_a?(Num) && n.is_minus1?)
+    def minus1?
+      [1, -1.0].include?(self) || (is_a?(Num) && n.minus1?)
     end
 
     def distributive?(ope1, ope2)

--- a/lib/dydx/helper.rb
+++ b/lib/dydx/helper.rb
@@ -38,8 +38,8 @@ module Dydx
       [0, 0.0].include?(self) || (is_a?(Num) && n.zero?)
     end
 
-    def is_1?
-      [1, 1.0].include?(self) || (is_a?(Num) && n.is_1?)
+    def one?
+      [1, 1.0].include?(self) || (is_a?(Num) && n.one?)
     end
 
     def is_minus1?
@@ -63,7 +63,7 @@ module Dydx
         (num? && x.num?) ||
         inverse?(:*, x)
       when :^
-        (num? && x.num?) || zero? || is_1?
+        (num? && x.num?) || zero? || one?
       end
     end
 

--- a/lib/dydx/helper.rb
+++ b/lib/dydx/helper.rb
@@ -34,8 +34,8 @@ module Dydx
       (is_a?(Num) || is_a?(Fixnum) || is_a?(Float)) || (is_a?(Inverse) && x.num?)
     end
 
-    def is_0?
-      [0, 0.0].include?(self) || (is_a?(Num) && n.is_0?)
+    def zero?
+      [0, 0.0].include?(self) || (is_a?(Num) && n.zero?)
     end
 
     def is_1?
@@ -63,7 +63,7 @@ module Dydx
         (num? && x.num?) ||
         inverse?(:*, x)
       when :^
-        (num? && x.num?) || is_0? || is_1?
+        (num? && x.num?) || zero? || is_1?
       end
     end
 
@@ -82,7 +82,7 @@ module Dydx
 
     # TODO: Cyclomatic complexity for combinable? is too high. [7/6]
     def is_multiple_of(x)
-      if is_0?
+      if zero?
         e0
       elsif self == x
         e1

--- a/lib/dydx/helper.rb
+++ b/lib/dydx/helper.rb
@@ -30,8 +30,8 @@ module Dydx
       inverse_ope(operator.super)
     end
 
-    def is_num?
-      (is_a?(Num) || is_a?(Fixnum) || is_a?(Float)) || (is_a?(Inverse) && x.is_num?)
+    def num?
+      (is_a?(Num) || is_a?(Fixnum) || is_a?(Float)) || (is_a?(Inverse) && x.num?)
     end
 
     def is_0?
@@ -54,16 +54,16 @@ module Dydx
     def combinable?(x, operator)
       case operator
       when :+
-        (is_num? && x.is_num?) ||
-        (formula?(:*) && (f.is_num? || g.is_num?)) && x.is_num? ||
+        (num? && x.num?) ||
+        (formula?(:*) && (f.num? || g.num?)) && x.num? ||
         like_term?(x) ||
         inverse?(:+, x)
       when :*
         self == x ||
-        (is_num? && x.is_num?) ||
+        (num? && x.num?) ||
         inverse?(:*, x)
       when :^
-        (is_num? && x.is_num?) || is_0? || is_1?
+        (num? && x.num?) || is_0? || is_1?
       end
     end
 
@@ -86,7 +86,7 @@ module Dydx
         e0
       elsif self == x
         e1
-      # elsif is_num? && x.is_num? && (self % x == 0)
+      # elsif num? && x.num? && (self % x == 0)
       #   _(n / x.n)
       elsif multiplication? && (f == x || g == x)
         f == x ? g : f

--- a/spec/lib/helper_spec.rb
+++ b/spec/lib/helper_spec.rb
@@ -9,8 +9,8 @@ describe Helper do
     it { expect(1.one?).to be_true }
     it { expect(_(1).one?).to be_true }
     it { expect(inverse(1, :*).one?).to be_true }
-    it { expect(-1.is_minus1?).to be_true }
-    it { expect(_(-1).is_minus1?).to be_true }
+    it { expect(-1.minus1?).to be_true }
+    it { expect(_(-1).minus1?).to be_true }
   end
 
   context '#is_multiple_of' do

--- a/spec/lib/helper_spec.rb
+++ b/spec/lib/helper_spec.rb
@@ -6,9 +6,9 @@ describe Helper do
     it { expect(0.zero?).to be_true }
     it { expect(_(0).zero?).to be_true }
     it { expect(inverse(0, :+).zero?).to be_true }
-    it { expect(1.is_1?).to be_true }
-    it { expect(_(1).is_1?).to be_true }
-    it { expect(inverse(1, :*).is_1?).to be_true }
+    it { expect(1.one?).to be_true }
+    it { expect(_(1).one?).to be_true }
+    it { expect(inverse(1, :*).one?).to be_true }
     it { expect(-1.is_minus1?).to be_true }
     it { expect(_(-1).is_minus1?).to be_true }
   end

--- a/spec/lib/helper_spec.rb
+++ b/spec/lib/helper_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 describe Helper do
   include Helper
   context '#is_n?' do
-    it { expect(0.is_0?).to be_true }
-    it { expect(_(0).is_0?).to be_true }
-    it { expect(inverse(0, :+).is_0?).to be_true }
+    it { expect(0.zero?).to be_true }
+    it { expect(_(0).zero?).to be_true }
+    it { expect(inverse(0, :+).zero?).to be_true }
     it { expect(1.is_1?).to be_true }
     it { expect(_(1).is_1?).to be_true }
     it { expect(inverse(1, :*).is_1?).to be_true }


### PR DESCRIPTION
`Dydx::Helper` の `is_num?`, `is_0?`, `is_1?`, `is_minus1?` が適切な名前でなく， rubocop の caution が発生するため，それぞれ `num?`, `zero?`, `one?`, `minus1?` に変更しました．
同様に， `Dydx::Helper#is_multiple_of` に対しても caution が発生していますが，このメソッドは真偽値のみを返すわけではないので， `multiple_of` と `multiple_of?` どちらに変更するべきか決めかねたため，手を加えませんでした．
