### PR TITLE
add dependency to gemspec

### DIFF
--- a/q_lang.gemspec
+++ b/q_lang.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency "dydx", '~> 0.1.41421'
+  spec.add_dependency "pry", '~> 0.10.1'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
when I type

`bundle exec qlang -i`

then

```
/Users/taish/.rbenv/versions/2.1.3/lib/ruby/gems/2.1.0/gems/qlang-0.0.27180000/lib/qlang/lexer/wrap_lexer.rb:1:in `require': cannot load such file -- pry (LoadError)
```

So I added dependency to gemspec .

But I didn't see your code.
Maybe you might write a wrong for debug lol
If so, Please close
