### PR TITLE
Ignore .ruby-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ tmp
 *.o
 *.a
 mkmf.log
+.ruby-version


### PR DESCRIPTION
Just adding an ignore for people using a Ruby version manager.
