### PR TITLE
Added OS X Caveat to Installation Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Install the `hilbert` gem.
 
     $ gem install hilbert
 
+### Note to OS X Users: If the above `gem` command does not work with the stock version of Ruby (due to not being able to build a target indicated in the Makefile), then you will need to install a version of Ruby that includes the appropriate header files. Using [homebrew](http://brew.sh/) (`brew install ruby`) will suffice.
+
 ## Interpreter
 
     $ hilbert -i


### PR DESCRIPTION
I was unable to install Hilbert with the stock version of Ruby on OS X Mavericks, so I added a blurb to the installation instructions, notifying OS X users to install a replacement Ruby (via, eg, Homebrew) and use that.
